### PR TITLE
Implementa JWT como header X-Auth-Token en servicios API

### DIFF
--- a/lib/api/service/noticia_sevice.dart
+++ b/lib/api/service/noticia_sevice.dart
@@ -6,17 +6,45 @@ import 'package:abaez/domain/noticia.dart';
 import 'package:dio/dio.dart';
 import 'package:abaez/constants.dart';
 import 'package:flutter/foundation.dart';
+import 'package:abaez/helpers/secure_storage_service.dart';
 
 class NoticiaService {
-  final Dio _dioNew = Dio(BaseOptions(
-    baseUrl: ApiConfig.beeceptorBaseUrl, // URL base para los endpoints
-    connectTimeout: const Duration(seconds: CategoriaConstantes.timeoutSeconds), // Tiempo de conexión
-    receiveTimeout: const Duration(seconds: CategoriaConstantes.timeoutSeconds), // Tiempo de recepción
-    headers: {
-      'Authorization': 'Bearer ${ApiConfig.beeceptorApiKey}', // Añadir API Key
-      'Content-Type': 'application/json',
-    },
-  ));
+  final SecureStorageService _secureStorage = SecureStorageService();
+  late final Dio _dioNew;
+  
+  NoticiaService() {
+    _dioNew = Dio(BaseOptions(
+      baseUrl: ApiConfig.beeceptorBaseUrl, // URL base para los endpoints
+      connectTimeout: const Duration(seconds: CategoriaConstantes.timeoutSeconds), // Tiempo de conexión
+      receiveTimeout: const Duration(seconds: CategoriaConstantes.timeoutSeconds), // Tiempo de recepción
+      headers: {
+        'Authorization': 'Bearer ${ApiConfig.beeceptorApiKey}', // Añadir API Key
+        'Content-Type': 'application/json',
+      },
+    ));
+    
+    // Interceptor para añadir el token JWT a cada solicitud
+    _dioNew.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        // Obtener el JWT del almacenamiento seguro
+        final jwt = await _secureStorage.getJwt();
+        if (jwt != null && jwt.isNotEmpty) {
+          // Añadir el JWT como header X-Auth-Token
+          options.headers['X-Auth-Token'] = jwt;
+        } else {
+          // Si no hay JWT, lanzar un error
+          return handler.reject(
+            DioException(
+              requestOptions: options,
+              error: 'No se encontró el token de autenticación',
+              type: DioExceptionType.unknown,
+            ),
+          );
+        }
+        return handler.next(options);
+      },
+    ));
+  }
  
   /// Obtiene todas las noticias de la API
   Future<List<Noticia>> getNoticias() async {

--- a/lib/api/service/reporte_service.dart
+++ b/lib/api/service/reporte_service.dart
@@ -4,39 +4,66 @@ import 'package:abaez/exceptions/api_exception.dart';
 import 'package:abaez/domain/reporte.dart';
 import 'package:dio/dio.dart';
 import 'package:abaez/constants.dart';
+import 'package:abaez/helpers/secure_storage_service.dart';
 
 class ReporteService {
-  final Dio _dio = Dio(BaseOptions(
-    baseUrl: ApiConfig.beeceptorBaseUrl, // URL base para los endpoints
-    connectTimeout: const Duration(seconds: CategoriaConstantes.timeoutSeconds), // Tiempo de conexión
-    receiveTimeout: const Duration(seconds:CategoriaConstantes.timeoutSeconds), // Tiempo de recepción
-    headers: {
-            'Authorization': 'Bearer ${ApiConfig.beeceptorApiKey}', // Añadir API Key
-            'Content-Type': 'application/json',
-          },
-  ));
+  final SecureStorageService _secureStorage = SecureStorageService();
+  late final Dio _dio;
+  
+  ReporteService() {
+    _dio = Dio(BaseOptions(
+      baseUrl: ApiConfig.beeceptorBaseUrl, // URL base para los endpoints
+      connectTimeout: const Duration(seconds: CategoriaConstantes.timeoutSeconds), // Tiempo de conexión
+      receiveTimeout: const Duration(seconds:CategoriaConstantes.timeoutSeconds), // Tiempo de recepción
+      headers: {
+              'Authorization': 'Bearer ${ApiConfig.beeceptorApiKey}', // Añadir API Key
+              'Content-Type': 'application/json',
+            },
+    ));
+    
+    // Interceptor para añadir el token JWT a cada solicitud
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        // Obtener el JWT del almacenamiento seguro
+        final jwt = await _secureStorage.getJwt();
+        if (jwt != null && jwt.isNotEmpty) {
+          // Añadir el JWT como header X-Auth-Token
+          options.headers['X-Auth-Token'] = jwt;
+        } else {
+          // Si no hay JWT, lanzar un error
+          return handler.reject(
+            DioException(
+              requestOptions: options,
+              error: 'No se encontró el token de autenticación',
+              type: DioExceptionType.unknown,
+            ),
+          );
+        }
+        return handler.next(options);
+      },
+    ));
+  }
 
   // URL base para los endpoints de reportes
   final String _baseUrl = '/reportes';
-
   /// Manejo centralizado de errores
   void _handleError(DioException e) {
     if (e.type == DioExceptionType.connectionTimeout || e.type == DioExceptionType.receiveTimeout) {
-      throw Exception(CategoriaConstantes.errorTimeout);
+      throw ApiException(CategoriaConstantes.errorTimeout);
     }
 
     final statusCode = e.response?.statusCode;
     switch (statusCode) {
       case 400:
-        throw Exception(CategoriaConstantes.mensajeError);
+        throw ApiException(CategoriaConstantes.mensajeError, statusCode: 400);
       case 401:
-        throw Exception(ErrorConstantes.errorUnauthorized);
+        throw ApiException(ErrorConstantes.errorUnauthorized, statusCode: 401);
       case 404:
-        throw Exception(ErrorConstantes.errorNotFound);
+        throw ApiException(ErrorConstantes.errorNotFound, statusCode: 404);
       case 500:
-        throw Exception(ErrorConstantes.errorServer);
+        throw ApiException(ErrorConstantes.errorServer, statusCode: 500);
       default:
-        throw Exception('Error desconocido: ${statusCode ?? 'Sin código'}');
+        throw ApiException('Error desconocido: ${statusCode ?? 'Sin código'}', statusCode: statusCode);
     }
   }
   /// Obtiene todos los reportes


### PR DESCRIPTION
-Agrega interceptores para incluir automáticamente el JWT en todas las solicitudes API
-Implementa validación del token en todos los
servicios (NoticiaService, CategoriaService,
ComentariosService, ReporteService)
-Lanza ApiException cuando no se encuentra token
de autenticación